### PR TITLE
Add Discord embed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Then add **@stephenyeargin/hubot-openweathermap** to your `external-scripts.json
 
 | Environment Variables    | Required? | Description                              |
 | ------------------------ | :-------: | ---------------------------------------- |
-| `HUBOT_OPEN_WEATHER_MAP_API_KEY`  | Yes       | API key from the developer console       |
+| `HUBOT_OPEN_WEATHER_MAP_API_KEY`  | Yes | API key from the developer console |
+| `HUBOT_OPEN_WEATHER_MAP_PLAIN_TEXT`[^1] | No | If true, avoids custom formatting for the Hubot adapter |
 | `HUBOT_DEFAULT_LATITUDE` | No | Latitude for default query of `hubot weather` |
 | `HUBOT_DEFAULT_LONGITUDE` | No | Longitude for default query of `hubot weather` |
 
@@ -36,3 +37,5 @@ hubot> Currently Clouds and 49F/10C in Nashville
 ### Slack
 
 ![screenshot](./screenshot.png)
+
+[^1]: Necessary if your Hubot instance is running the `hubot-discord` and not `@hubot-friends/hubot-discord` because the former will appear as `[object Object]`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Then add **@stephenyeargin/hubot-openweathermap** to your `external-scripts.json
 | Environment Variables    | Required? | Description                              |
 | ------------------------ | :-------: | ---------------------------------------- |
 | `HUBOT_OPEN_WEATHER_MAP_API_KEY`  | Yes | API key from the developer console |
-| `HUBOT_OPEN_WEATHER_MAP_PLAIN_TEXT`[^1] | No | If true, avoids custom formatting for the Hubot adapter |
 | `HUBOT_DEFAULT_LATITUDE` | No | Latitude for default query of `hubot weather` |
 | `HUBOT_DEFAULT_LONGITUDE` | No | Longitude for default query of `hubot weather` |
 
@@ -37,5 +36,3 @@ hubot> Currently Clouds and 49F/10C in Nashville
 ### Slack
 
 ![screenshot](./screenshot.png)
-
-[^1]: Necessary if your Hubot instance is running the `hubot-discord` and not `@hubot-friends/hubot-discord` because the former will appear as `[object Object]`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "dayjs": "^1.11.10"
+        "dayjs": "^1.11.10",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "chai": "^4.3.10",
@@ -26,6 +27,7 @@
         "sinon-chai": "^3.7.0"
       },
       "peerDependencies": {
+        "discord.js": "^14",
         "hubot": ">=3 || 0.0.0-development"
       }
     },
@@ -36,6 +38,112 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
+      "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
+      "peer": true,
+      "dependencies": {
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/shapeshift": "^3.9.3",
+        "discord-api-types": "0.37.61",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
+      "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
+      "peer": true,
+      "dependencies": {
+        "discord-api-types": "0.37.61"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
+      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
+      "peer": true,
+      "dependencies": {
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/async-queue": "^1.5.0",
+        "@sapphire/snowflake": "^3.5.1",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.61",
+        "magic-bytes.js": "^1.5.0",
+        "tslib": "^2.6.2",
+        "undici": "5.27.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
+      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
+      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
+      "peer": true,
+      "dependencies": {
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/ws": "^8.5.9",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.61",
+        "tslib": "^2.6.2",
+        "ws": "^8.14.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -137,6 +245,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -252,6 +369,39 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.1.tgz",
+      "integrity": "sha512-1RdpsmDQR/aWfp8oJzPtn4dNQrbpqSL5PIA0uAB/XwerPXUf994Ug1au1e7uGcD7ei8/F63UDjr5GWps1g/HxQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.5.tgz",
+      "integrity": "sha512-AGdHe+51gF7D3W8hBfuSFLBocURDCXVQczScTHXDS3RpNjNgrktIx/amlz5y8nHhm8SAdFt/X8EF8ZSfjJ0tnA==",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "peer": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
@@ -302,11 +452,39 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
+      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
+      "peer": true,
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1121,6 +1299,37 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.37.61",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
+      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw==",
+      "peer": true
+    },
+    "node_modules/discord.js": {
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
+      "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
+      "peer": true,
+      "dependencies": {
+        "@discordjs/builders": "^1.7.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
+        "@discordjs/ws": "^1.0.2",
+        "@sapphire/snowflake": "3.5.1",
+        "@types/ws": "8.5.9",
+        "discord-api-types": "0.37.61",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "2.6.2",
+        "undici": "5.27.2",
+        "ws": "8.14.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
       }
     },
     "node_modules/doctrine": {
@@ -1981,8 +2190,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2975,6 +3183,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -2986,6 +3200,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "peer": true
     },
     "node_modules/log": {
       "version": "6.3.1",
@@ -3054,6 +3274,12 @@
       "dependencies": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.7.0.tgz",
+      "integrity": "sha512-YzVU2+/hrjwx8xcgAw+ffNq3jkactpj+f1iSL4LonrFKhvnwDzHSqtFdk/MMRP53y9ScouJ7cKEnqYsJwsHoYA==",
+      "peer": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3930,7 +4156,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3945,7 +4170,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4309,6 +4533,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ==",
+      "peer": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -4320,6 +4550,12 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
     },
     "node_modules/type": {
       "version": "2.7.2",
@@ -4450,6 +4686,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+      "peer": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "peer": true
+    },
     "node_modules/uni-global": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
@@ -4553,6 +4807,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -4565,8 +4840,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/stephenyeargin/hubot-openweathermap/issues"
   },
   "peerDependencies": {
+    "discord.js": "^14",
     "hubot": ">=3 || 0.0.0-development"
   },
   "devDependencies": {
@@ -42,6 +43,7 @@
     "node": "18.19.0"
   },
   "dependencies": {
-    "dayjs": "^1.11.10"
+    "dayjs": "^1.11.10",
+    "semver": "^7.5.4"
   }
 }

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -13,6 +13,7 @@
 const dayjs = require('dayjs');
 const semver = require('semver');
 const { EmbedBuilder: DiscordEmbedBuilder } = require('discord.js');
+const hubotVersion = require('hubot/package.json').version || '0.0.0';
 
 module.exports = (robot) => {
   const baseUrl = 'https://api.openweathermap.org/data/2.5/weather';
@@ -129,7 +130,7 @@ module.exports = (robot) => {
       };
     }
     if (robot.adapterName && robot.adapterName.indexOf('discord') > -1) {
-      if (semver.lt(robot.parseVersion(), '11.0.0')) {
+      if (semver.lt(robot.parseVersion() || hubotVersion, '11.0.0')) {
         robot.logger.info('@stephenyeargin/hubot-openweathermap: Unable to use Discord embeds if Hubot < v11');
         return textFallback;
       }
@@ -232,7 +233,7 @@ module.exports = (robot) => {
       };
     }
     if (robot.adapterName && robot.adapterName.indexOf('discord') > -1) {
-      if (semver.lt(robot.parseVersion(), '11.0.0')) {
+      if (semver.lt(robot.parseVersion() || hubotVersion, '11.0.0')) {
         robot.logger.info('@stephenyeargin/hubot-openweathermap: Unable to use Discord embeds if Hubot < v11');
         return textFallback;
       }

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -7,7 +7,6 @@
 //
 // Configuration:
 //   HUBOT_OPEN_WEATHER_MAP_API_KEY - API Key
-//   HUBOT_OPEN_WEATHER_MAP_PLAIN_TEXT - Force response to be plain text
 //   HUBOT_DEFAULT_LATITUDE - Default latitude for Hubot interactions
 //   HUBOT_DEFAULT_LONGITUDE - Default longitude for Hubot interactions
 
@@ -85,9 +84,6 @@ module.exports = (robot) => {
       output.push(`- ${alert.properties.headline}`);
     });
     const textFallback = output.join('\n');
-    if (process.env.HUBOT_OPEN_WEATHER_MAP_PLAIN_TEXT) {
-      return textFallback;
-    }
     if (robot.adapterName && robot.adapterName.indexOf('slack') > -1) {
       const attachments = json.features.map((alert) => ({
         author_icon: 'https://github.com/NOAAGov.png',
@@ -197,9 +193,6 @@ module.exports = (robot) => {
 
   const formatWeather = (json) => {
     const textFallback = `Currently ${json.weather[0].description} and ${formatUnits(json.main.temp, 'imperial')}F/${formatUnits(json.main.temp, 'metric')}C in ${json.name}`;
-    if (process.env.HUBOT_OPEN_WEATHER_MAP_PLAIN_TEXT) {
-      return textFallback;
-    }
     if (robot.adapterName && robot.adapterName.indexOf('slack') > -1) {
       return {
         attachments: [{

--- a/test/adapters/discord-legacy.js
+++ b/test/adapters/discord-legacy.js
@@ -1,0 +1,6 @@
+// Description
+//   Mock Discord adapter for older Hubot
+module.exports = (robot) => {
+  robot.adapterName = 'discord';
+  robot.parseVersion = () => '3.0.0';
+};

--- a/test/adapters/discord.js
+++ b/test/adapters/discord.js
@@ -1,0 +1,6 @@
+// Description
+//   Mock Discord adapter
+module.exports = (robot) => {
+  robot.adapterName = 'discord';
+  robot.parseVersion = () => '11.0.0';
+};

--- a/test/openweathermap.test.js
+++ b/test/openweathermap.test.js
@@ -47,7 +47,7 @@ describe('hubot-openweathermap', () => {
     it('hubot responds with message', () => {
       expect(room.messages).to.eql([
         ['alice', 'hubot weather'],
-        ['hubot', 'Currently Clouds and 50F/10C in Nashville'],
+        ['hubot', 'Currently broken clouds and 50F/10C in Nashville'],
       ]);
     });
   });
@@ -72,7 +72,7 @@ describe('hubot-openweathermap', () => {
     it('hubot responds with message', () => {
       expect(room.messages).to.eql([
         ['alice', 'hubot weather'],
-        ['hubot', 'Currently Clouds and 50F/10C in Nashville'],
+        ['hubot', 'Currently broken clouds and 50F/10C in Nashville'],
         [
           'hubot',
           'Current watches, warnings, and advisories for Davidson County (TNC037) TN:\n'
@@ -103,7 +103,7 @@ describe('hubot-openweathermap', () => {
     it('hubot responds with message', () => {
       expect(room.messages).to.eql([
         ['alice', 'hubot weather 37206'],
-        ['hubot', 'Currently Clouds and 50F/10C in Nashville'],
+        ['hubot', 'Currently broken clouds and 50F/10C in Nashville'],
       ]);
     });
   });
@@ -128,7 +128,7 @@ describe('hubot-openweathermap', () => {
     it('hubot responds with message', () => {
       expect(room.messages).to.eql([
         ['alice', 'hubot weather seattle, WA'],
-        ['hubot', 'Currently Clouds and 47F/8C in Seattle'],
+        ['hubot', 'Currently scattered clouds and 47F/8C in Seattle'],
         [
           'hubot',
           'Current watches, warnings, and advisories for King County (WAC033) WA:\n'
@@ -143,7 +143,7 @@ describe('hubot-openweathermap', () => {
       nock('https://api.openweathermap.org')
         .get('/data/2.5/weather')
         .query({ q: 'seattle,WA,US', appid: 'abcdef' })
-        .replyWithError(new Error('Internal service error'));
+        .replyWithError(new Error('Mock internal service error'));
 
       room.user.say('alice', 'hubot weather seattle, WA');
       setTimeout(done, 100);
@@ -152,7 +152,7 @@ describe('hubot-openweathermap', () => {
     it('hubot responds with message', () => {
       expect(room.messages).to.eql([
         ['alice', 'hubot weather seattle, WA'],
-        ['hubot', 'Encountered error: Error: Internal service error'],
+        ['hubot', 'Encountered error: Error: Mock internal service error'],
       ]);
     });
   });

--- a/test/openweathermap_discord.test.js
+++ b/test/openweathermap_discord.test.js
@@ -1,0 +1,507 @@
+/* global describe, context it, beforeEach, afterEach */
+
+const Helper = require('hubot-test-helper');
+const chai = require('chai');
+chai.use(require('sinon-chai'));
+const nock = require('nock');
+
+const helper = new Helper([
+  './adapters/discord.js',
+  './../src/openweathermap.js',
+]);
+const helperLegacy = new Helper([
+  './adapters/discord-legacy.js',
+  './../src/openweathermap.js',
+]);
+
+const { expect } = chai;
+
+describe('hubot-openweathermap discord', () => {
+  let room = null;
+
+  beforeEach(() => {
+    process.env.HUBOT_OPEN_WEATHER_MAP_API_KEY = 'abcdef';
+    process.env.HUBOT_DEFAULT_LATITUDE = '36.1798';
+    process.env.HUBOT_DEFAULT_LONGITUDE = '-86.7411';
+    room = helper.createRoom();
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    room.destroy();
+    nock.cleanAll();
+    delete process.env.HUBOT_OPEN_WEATHER_MAP_API_KEY;
+    delete process.env.HUBOT_DEFAULT_LATITUDE;
+    delete process.env.HUBOT_DEFAULT_LONGITUDE;
+  });
+
+  context('get weather for configured coordinates', () => {
+    beforeEach((done) => {
+      nock('https://api.openweathermap.org')
+        .get('/data/2.5/weather')
+        .query({ lat: '36.1798', lon: '-86.7411', appid: 'abcdef' })
+        .replyWithFile(200, './test/fixtures/api.openweathermap.org-data-2.5-weather-37206.json');
+      nock('https://api.weather.gov')
+        .get('/points/36.1798,-86.7411')
+        .replyWithFile(200, './test/fixtures/weather.gov-points-36.1798--86.7411.geojson');
+      nock('https://api.weather.gov')
+        .get('/alerts/active/zone/TNC037')
+        .replyWithFile(200, './test/fixtures/weather.gov-alerts-active-zone-TNC037-none.geojson');
+
+      room.user.say('alice', 'hubot weather');
+      setTimeout(done, 100);
+    });
+
+    it('hubot responds with message', () => {
+      expect(room.messages).to.eql([
+        ['alice', 'hubot weather'],
+        [
+          'hubot',
+          {
+            embeds: [{
+              data: {
+                title: 'Weather in Nashville',
+                url: 'https://openweathermap.org/weathermap?zoom=12&lat=36.1798&lon=-86.7411',
+                author: {
+                  name: 'OpenWeather',
+                  url: 'https://openweathermap.org/',
+                  icon_url: 'https://github.com/openweathermap.png',
+                },
+                fields: [
+                  {
+                    name: 'Conditions',
+                    value: 'Clouds (broken clouds)',
+                    inline: true,
+                  },
+                  {
+                    name: 'Temperature',
+                    value: '50F/10C',
+                    inline: true,
+                  },
+                  {
+                    name: 'Feels Like',
+                    value: '48F/9C',
+                    inline: true,
+                  },
+                  {
+                    name: 'Humidity',
+                    value: '77%',
+                    inline: true,
+                  },
+                ],
+                thumbnail: {
+                  url: 'https://openweathermap.org/img/wn/04d@4x.png',
+                },
+                color: 15429195,
+                footer: {
+                  text: 'Weather data provided by OpenWeather',
+                  icon_url: 'https://github.com/openweathermap.png',
+                },
+                timestamp: '2023-12-26T17:28:39.000Z',
+              },
+            }],
+          },
+        ],
+      ]);
+    });
+  });
+
+  context('get weather for configured coordinates with active alerts', () => {
+    beforeEach((done) => {
+      nock('https://api.openweathermap.org')
+        .get('/data/2.5/weather')
+        .query({ lat: '36.1798', lon: '-86.7411', appid: 'abcdef' })
+        .replyWithFile(200, './test/fixtures/api.openweathermap.org-data-2.5-weather-37206.json');
+      nock('https://api.weather.gov')
+        .get('/points/36.1798,-86.7411')
+        .replyWithFile(200, './test/fixtures/weather.gov-points-36.1798--86.7411.geojson');
+      nock('https://api.weather.gov')
+        .get('/alerts/active/zone/TNC037')
+        .replyWithFile(200, './test/fixtures/weather.gov-alerts-active-zone-TNC037-tornadoes.geojson');
+
+      room.user.say('alice', 'hubot weather');
+      setTimeout(done, 100);
+    });
+
+    it('hubot responds with message', () => {
+      expect(room.messages).to.eql([
+        ['alice', 'hubot weather'],
+        [
+          'hubot',
+          {
+            embeds: [
+              {
+                data: {
+                  author: {
+                    icon_url: 'https://github.com/openweathermap.png',
+                    name: 'OpenWeather',
+                    url: 'https://openweathermap.org/',
+                  },
+                  color: 15429195,
+                  fields: [
+                    {
+                      inline: true,
+                      name: 'Conditions',
+                      value: 'Clouds (broken clouds)',
+                    },
+                    {
+                      inline: true,
+                      name: 'Temperature',
+                      value: '50F/10C',
+                    },
+                    {
+                      inline: true,
+                      name: 'Feels Like',
+                      value: '48F/9C',
+                    },
+                    {
+                      inline: true,
+                      name: 'Humidity',
+                      value: '77%',
+                    },
+                  ],
+                  footer: {
+                    icon_url: 'https://github.com/openweathermap.png',
+                    text: 'Weather data provided by OpenWeather',
+                  },
+                  thumbnail: {
+                    url: 'https://openweathermap.org/img/wn/04d@4x.png',
+                  },
+                  timestamp: '2023-12-26T17:28:39.000Z',
+                  title: 'Weather in Nashville',
+                  url: 'https://openweathermap.org/weathermap?zoom=12&lat=36.1798&lon=-86.7411',
+                },
+              },
+            ],
+          },
+        ],
+        [
+          'hubot',
+          {
+            embeds: [
+              {
+                data: {
+                  author: {
+                    icon_url: 'https://github.com/NOAAGov.png',
+                    name: 'Weather.gov',
+                    url: 'https://weather.gov/',
+                  },
+                  color: 5697536,
+                  description: '```\n* WHAT...Flooding caused by excessive rainfall is expected.\n\n* WHERE...A portion of Middle Tennessee, including the following\ncounties, Cheatham, Davidson, Macon, Robertson, Sumner and\nTrousdale.\n\n* WHEN...Until 900 PM CST.\n\n* IMPACTS...Minor flooding in low-lying and poor drainage areas.\n\n* ADDITIONAL DETAILS...\n- At 548 PM CST, Doppler radar indicated heavy rain due to\nthunderstorms. Minor flooding is ongoing or expected to begin\nshortly in the advisory area. Between 1 and 2 inches of rain\nhave fallen.\n- Some locations that will experience flooding include...\nGallatin, Ashland City, Lafayette, Madison, Hendersonville,\nGoodlettsville, White House, Millersville, Greenbrier,\nWestmoreland, Ridgetop, Old Hickory, Joelton, Cottontown,\nBledsoe Creek State Park, Whites Creek, Bethpage, Beaman Park\nand Bells Bend.\n- http://www.weather.gov/safety/flood\n```',
+                  fields: [
+                    {
+                      inline: true,
+                      name: 'Severity',
+                      value: 'Minor',
+                    },
+                    {
+                      inline: true,
+                      name: 'Certainty',
+                      value: 'Likely',
+                    },
+                    {
+                      inline: false,
+                      name: 'Areas Affected',
+                      value: 'Cheatham, TN; Davidson, TN; Macon, TN; Robertson, TN; Sumner, TN; Trousdale, TN',
+                    },
+                    {
+                      inline: false,
+                      name: 'Instructions / Response',
+                      value: "Turn around, don't drown when encountering flooded roads. Most flood\ndeaths occur in vehicles.",
+                    },
+                  ],
+                  footer: {
+                    icon_url: 'https://github.com/NOAAGov.png',
+                    text: 'Alerts provided by the National Weather Service',
+                  },
+                  timestamp: '2023-12-09T23:48:00.000Z',
+                  title: 'Flood Advisory issued December 9 at 5:48PM CST until December 9 at 9:00PM CST by NWS Nashville TN',
+                },
+              },
+              {
+                data: {
+                  author: {
+                    icon_url: 'https://github.com/NOAAGov.png',
+                    name: 'Weather.gov',
+                    url: 'https://weather.gov/',
+                  },
+                  color: 16726072,
+                  description: '```\nTORNADO WATCH 714 REMAINS VALID UNTIL 7 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN TENNESSEE THIS WATCH INCLUDES 14 COUNTIES\n\nIN MIDDLE TENNESSEE\n\nDAVIDSON              HICKMAN               LAWRENCE\nLEWIS                 MACON                 MAURY\nPERRY                 RUTHERFORD            SMITH\nSUMNER                TROUSDALE             WAYNE\nWILLIAMSON            WILSON\n\nTHIS INCLUDES THE CITIES OF BRENTWOOD, CARTHAGE, CENTERVILLE,\nCLIFTON, COLLINWOOD, COLUMBIA, FRANKLIN, GALLATIN,\nGOODLETTSVILLE, GORDONSVILLE, HARTSVILLE, HENDERSONVILLE,\nHOHENWALD, LA VERGNE, LAFAYETTE, LAWRENCEBURG, LEBANON, LINDEN,\nLOBELVILLE, MOUNT JULIET, MURFREESBORO, NASHVILLE, SMYRNA,\nSOUTH CARTHAGE, AND WAYNESBORO.\n```',
+                  fields: [
+                    {
+                      inline: true,
+                      name: 'Severity',
+                      value: 'Extreme',
+                    },
+                    {
+                      inline: true,
+                      name: 'Certainty',
+                      value: 'Possible',
+                    },
+                    {
+                      inline: false,
+                      name: 'Areas Affected',
+                      value: 'Davidson, TN; Hickman, TN; Lawrence, TN; Lewis, TN; Macon, TN; Maury, TN; Perry, TN; Rutherford, TN; Smith, TN; Sumner, TN; Trousdale, TN; Wayne, TN; Williamson, TN; Wilson, TN',
+                    },
+                    {
+                      inline: false,
+                      name: 'Instructions / Response',
+                      value: 'Monitor',
+                    },
+                  ],
+                  footer: {
+                    icon_url: 'https://github.com/NOAAGov.png',
+                    text: 'Alerts provided by the National Weather Service',
+                  },
+                  timestamp: '2023-12-09T23:38:00.000Z',
+                  title: 'Tornado Watch issued December 9 at 5:38PM CST until December 9 at 7:00PM CST by NWS Nashville TN',
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+    });
+  });
+
+  context('get weather for a zip code', () => {
+    beforeEach((done) => {
+      nock('https://api.openweathermap.org')
+        .get('/data/2.5/weather')
+        .query({ zip: 37206, appid: 'abcdef' })
+        .replyWithFile(200, './test/fixtures/api.openweathermap.org-data-2.5-weather-37206.json');
+      nock('https://api.weather.gov')
+        .get('/points/36.1798,-86.7411')
+        .replyWithFile(200, './test/fixtures/weather.gov-points-36.1798--86.7411.geojson');
+      nock('https://api.weather.gov')
+        .get('/alerts/active/zone/TNC037')
+        .replyWithFile(200, './test/fixtures/weather.gov-alerts-active-zone-TNC037-none.geojson');
+
+      room.user.say('alice', 'hubot weather 37206');
+      setTimeout(done, 100);
+    });
+
+    it('hubot responds with message', () => {
+      expect(room.messages).to.eql([
+        ['alice', 'hubot weather 37206'],
+        [
+          'hubot',
+          {
+            embeds: [
+              {
+                data: {
+                  author: {
+                    icon_url: 'https://github.com/openweathermap.png',
+                    name: 'OpenWeather',
+                    url: 'https://openweathermap.org/',
+                  },
+                  color: 15429195,
+                  fields: [
+                    {
+                      inline: true,
+                      name: 'Conditions',
+                      value: 'Clouds (broken clouds)',
+                    },
+                    {
+                      inline: true,
+                      name: 'Temperature',
+                      value: '50F/10C',
+                    },
+                    {
+                      inline: true,
+                      name: 'Feels Like',
+                      value: '48F/9C',
+                    },
+                    {
+                      inline: true,
+                      name: 'Humidity',
+                      value: '77%',
+                    },
+                  ],
+                  footer: {
+                    icon_url: 'https://github.com/openweathermap.png',
+                    text: 'Weather data provided by OpenWeather',
+                  },
+                  thumbnail: {
+                    url: 'https://openweathermap.org/img/wn/04d@4x.png',
+                  },
+                  timestamp: '2023-12-26T17:28:39.000Z',
+                  title: 'Weather in Nashville',
+                  url: 'https://openweathermap.org/weathermap?zoom=12&lat=36.1798&lon=-86.7411',
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+    });
+  });
+
+  context('get weather for a city', () => {
+    beforeEach((done) => {
+      nock('https://api.openweathermap.org')
+        .get('/data/2.5/weather')
+        .query({ q: 'seattle,WA,US', appid: 'abcdef' })
+        .replyWithFile(200, './test/fixtures/api.openweathermap.org-data-2.5-weather-seattle.json');
+      nock('https://api.weather.gov')
+        .get('/points/47.6038,-122.3301')
+        .replyWithFile(200, './test/fixtures/weather.gov-points-47.6038--122.3301.geojson');
+      nock('https://api.weather.gov')
+        .get('/alerts/active/zone/WAC033')
+        .replyWithFile(200, './test/fixtures/weather.gov-alerts-active-zone-WAC033-wind.geojson');
+
+      room.user.say('alice', 'hubot weather seattle, WA');
+      setTimeout(done, 100);
+    });
+
+    it('hubot responds with message', () => {
+      expect(room.messages).to.eql([
+        ['alice', 'hubot weather seattle, WA'],
+        [
+          'hubot',
+          {
+            embeds: [
+              {
+                data: {
+                  author: {
+                    icon_url: 'https://github.com/openweathermap.png',
+                    name: 'OpenWeather',
+                    url: 'https://openweathermap.org/',
+                  },
+                  color: 15429195,
+                  fields: [
+                    {
+                      inline: true,
+                      name: 'Conditions',
+                      value: 'Clouds (scattered clouds)',
+                    },
+                    {
+                      inline: true,
+                      name: 'Temperature',
+                      value: '47F/8C',
+                    },
+                    {
+                      inline: true,
+                      name: 'Feels Like',
+                      value: '45F/7C',
+                    },
+                    {
+                      inline: true,
+                      name: 'Humidity',
+                      value: '90%',
+                    },
+                  ],
+                  footer: {
+                    icon_url: 'https://github.com/openweathermap.png',
+                    text: 'Weather data provided by OpenWeather',
+                  },
+                  thumbnail: {
+                    url: 'https://openweathermap.org/img/wn/03d@4x.png',
+                  },
+                  timestamp: '2023-12-26T18:56:40.000Z',
+                  title: 'Weather in Seattle',
+                  url: 'https://openweathermap.org/weathermap?zoom=12&lat=47.6038&lon=-122.3301',
+                },
+              },
+            ],
+          },
+        ],
+        [
+          'hubot',
+          {
+            embeds: [
+              {
+                data: {
+                  author: {
+                    icon_url: 'https://github.com/NOAAGov.png',
+                    name: 'Weather.gov',
+                    url: 'https://weather.gov/',
+                  },
+                  color: 16574522,
+                  description: '```\n* WHAT...East winds 20 to 35 mph with gusts 45 to 55 mph near gaps\nin the terrain.\n\n* WHERE...East Puget Sound Lowlands.\n\n* WHEN...From 6 PM this evening to 1 PM PST Wednesday.\n\n* IMPACTS...Gusty winds could blow around unsecured objects.\nTree limbs could be blown down and a few power outages may\nresult.\n```',
+                  fields: [
+                    {
+                      inline: true,
+                      name: 'Severity',
+                      value: 'Moderate',
+                    },
+                    {
+                      inline: true,
+                      name: 'Certainty',
+                      value: 'Likely',
+                    },
+                    {
+                      inline: false,
+                      name: 'Areas Affected',
+                      value: 'East Puget Sound Lowlands',
+                    },
+                    {
+                      inline: false,
+                      name: 'Instructions / Response',
+                      value: 'Use extra caution when driving, especially if operating a high\nprofile vehicle. Secure outdoor objects.',
+                    },
+                  ],
+                  footer: {
+                    icon_url: 'https://github.com/NOAAGov.png',
+                    text: 'Alerts provided by the National Weather Service',
+                  },
+                  timestamp: '2023-12-26T11:52:00.000Z',
+                  title: 'Wind Advisory issued December 26 at 3:52AM PST until December 27 at 1:00PM PST by NWS Seattle WA',
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+    });
+  });
+});
+
+describe('hubot-openweathermap discord legacy', () => {
+  let room = null;
+
+  beforeEach(() => {
+    process.env.HUBOT_OPEN_WEATHER_MAP_API_KEY = 'abcdef';
+    process.env.HUBOT_DEFAULT_LATITUDE = '36.1798';
+    process.env.HUBOT_DEFAULT_LONGITUDE = '-86.7411';
+    room = helperLegacy.createRoom();
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    room.destroy();
+    nock.cleanAll();
+    delete process.env.HUBOT_OPEN_WEATHER_MAP_API_KEY;
+    delete process.env.HUBOT_DEFAULT_LATITUDE;
+    delete process.env.HUBOT_DEFAULT_LONGITUDE;
+  });
+  context('return plaintext response if Hubot version is < 11', () => {
+    beforeEach((done) => {
+      nock('https://api.openweathermap.org')
+        .get('/data/2.5/weather')
+        .query({ q: 'seattle,WA,US', appid: 'abcdef' })
+        .replyWithFile(200, './test/fixtures/api.openweathermap.org-data-2.5-weather-seattle.json');
+      nock('https://api.weather.gov')
+        .get('/points/47.6038,-122.3301')
+        .replyWithFile(200, './test/fixtures/weather.gov-points-47.6038--122.3301.geojson');
+      nock('https://api.weather.gov')
+        .get('/alerts/active/zone/WAC033')
+        .replyWithFile(200, './test/fixtures/weather.gov-alerts-active-zone-WAC033-wind.geojson');
+
+      room.user.say('alice', 'hubot weather seattle, wa');
+      setTimeout(done, 100);
+    });
+
+    it('hubot responds with message', () => {
+      expect(room.messages).to.eql([
+        ['alice', 'hubot weather seattle, wa'],
+        ['hubot', 'Currently scattered clouds and 47F/8C in Seattle'],
+        [
+          'hubot',
+          'Current watches, warnings, and advisories for King County (WAC033) WA:\n'
+          + '- Wind Advisory issued December 26 at 3:52AM PST until December 27 at 1:00PM PST by NWS Seattle WA',
+        ],
+      ]);
+    });
+  });
+});

--- a/test/openweathermap_discord.test.js
+++ b/test/openweathermap_discord.test.js
@@ -499,7 +499,7 @@ describe('hubot-openweathermap discord legacy', () => {
         [
           'hubot',
           'Current watches, warnings, and advisories for King County (WAC033) WA:\n'
-          + '- Wind Advisory issued December 26 at 3:52AM PST until December 27 at 1:00PM PST by NWS Seattle WA',
+          + '- Wind Advisory issued December 26 at 3:52AM PST until December 27 at 1:00PM PST by NWS Seattle WA - https://alerts.weather.gov/search?id=urn:oid:2.49.0.1.840.0.03c9a16ab3afeeb61c14b4af6207edf30654fcb6.002.1',
         ],
       ]);
     });

--- a/test/openweathermap_slack.test.js
+++ b/test/openweathermap_slack.test.js
@@ -59,7 +59,7 @@ describe('hubot-openweathermap slack', () => {
                 author_link: 'https://openweathermap.org/',
                 author_name: 'OpenWeather',
                 color: '#eb6e4b',
-                fallback: 'Currently Clouds and 50F/10C in Nashville',
+                fallback: 'Currently broken clouds and 50F/10C in Nashville',
                 fields: [
                   {
                     short: true,
@@ -124,7 +124,7 @@ describe('hubot-openweathermap slack', () => {
                 author_link: 'https://openweathermap.org/',
                 author_name: 'OpenWeather',
                 color: '#eb6e4b',
-                fallback: 'Currently Clouds and 50F/10C in Nashville',
+                fallback: 'Currently broken clouds and 50F/10C in Nashville',
                 fields: [
                   {
                     short: true,
@@ -195,6 +195,7 @@ describe('hubot-openweathermap slack', () => {
                 pretext: 'Flood Advisory',
                 text: '```\n* WHAT...Flooding caused by excessive rainfall is expected.\n\n* WHERE...A portion of Middle Tennessee, including the following\ncounties, Cheatham, Davidson, Macon, Robertson, Sumner and\nTrousdale.\n\n* WHEN...Until 900 PM CST.\n\n* IMPACTS...Minor flooding in low-lying and poor drainage areas.\n\n* ADDITIONAL DETAILS...\n- At 548 PM CST, Doppler radar indicated heavy rain due to\nthunderstorms. Minor flooding is ongoing or expected to begin\nshortly in the advisory area. Between 1 and 2 inches of rain\nhave fallen.\n- Some locations that will experience flooding include...\nGallatin, Ashland City, Lafayette, Madison, Hendersonville,\nGoodlettsville, White House, Millersville, Greenbrier,\nWestmoreland, Ridgetop, Old Hickory, Joelton, Cottontown,\nBledsoe Creek State Park, Whites Creek, Bethpage, Beaman Park\nand Bells Bend.\n- http://www.weather.gov/safety/flood\n```',
                 title: 'Flood Advisory issued December 9 at 5:48PM CST until December 9 at 9:00PM CST by NWS Nashville TN',
+                footer: 'Alerts provided by the National Weather Service',
                 ts: 1702165680,
               },
               {
@@ -228,6 +229,7 @@ describe('hubot-openweathermap slack', () => {
                 mrkdwn_in: [
                   'text',
                 ],
+                footer: 'Alerts provided by the National Weather Service',
                 pretext: 'Tornado Watch',
                 text: '```\nTORNADO WATCH 714 REMAINS VALID UNTIL 7 PM CST THIS EVENING FOR\nTHE FOLLOWING AREAS\n\nIN TENNESSEE THIS WATCH INCLUDES 14 COUNTIES\n\nIN MIDDLE TENNESSEE\n\nDAVIDSON              HICKMAN               LAWRENCE\nLEWIS                 MACON                 MAURY\nPERRY                 RUTHERFORD            SMITH\nSUMNER                TROUSDALE             WAYNE\nWILLIAMSON            WILSON\n\nTHIS INCLUDES THE CITIES OF BRENTWOOD, CARTHAGE, CENTERVILLE,\nCLIFTON, COLLINWOOD, COLUMBIA, FRANKLIN, GALLATIN,\nGOODLETTSVILLE, GORDONSVILLE, HARTSVILLE, HENDERSONVILLE,\nHOHENWALD, LA VERGNE, LAFAYETTE, LAWRENCEBURG, LEBANON, LINDEN,\nLOBELVILLE, MOUNT JULIET, MURFREESBORO, NASHVILLE, SMYRNA,\nSOUTH CARTHAGE, AND WAYNESBORO.\n```',
                 title: 'Tornado Watch issued December 9 at 5:38PM CST until December 9 at 7:00PM CST by NWS Nashville TN',
@@ -271,7 +273,7 @@ describe('hubot-openweathermap slack', () => {
                 author_link: 'https://openweathermap.org/',
                 author_name: 'OpenWeather',
                 color: '#eb6e4b',
-                fallback: 'Currently Clouds and 50F/10C in Nashville',
+                fallback: 'Currently broken clouds and 50F/10C in Nashville',
                 fields: [
                   {
                     short: true,
@@ -336,7 +338,7 @@ describe('hubot-openweathermap slack', () => {
                 author_link: 'https://openweathermap.org/',
                 author_name: 'OpenWeather',
                 color: '#eb6e4b',
-                fallback: 'Currently Clouds and 47F/8C in Seattle',
+                fallback: 'Currently scattered clouds and 47F/8C in Seattle',
                 fields: [
                   {
                     short: true,
@@ -406,6 +408,7 @@ describe('hubot-openweathermap slack', () => {
                 pretext: 'Wind Advisory',
                 text: '```\n* WHAT...East winds 20 to 35 mph with gusts 45 to 55 mph near gaps\nin the terrain.\n\n* WHERE...East Puget Sound Lowlands.\n\n* WHEN...From 6 PM this evening to 1 PM PST Wednesday.\n\n* IMPACTS...Gusty winds could blow around unsecured objects.\nTree limbs could be blown down and a few power outages may\nresult.\n```',
                 title: 'Wind Advisory issued December 26 at 3:52AM PST until December 27 at 1:00PM PST by NWS Seattle WA',
+                footer: 'Alerts provided by the National Weather Service',
                 ts: 1703591520,
               },
             ],


### PR DESCRIPTION
Adds Discord embed support (similar to Slack attachments) for users running Hubot > v11. The current release of `hubot-discord` treats everything sent through it as a string, so the embed payload will appear as `[object Object]`.
